### PR TITLE
Issue #20 - Improvement to string matching methodology for player names/Implement get_player_url function

### DIFF
--- a/modules/scraper.py
+++ b/modules/scraper.py
@@ -212,6 +212,33 @@ def get_target_name(query):
     return target_name
 
 """
+Function to get the player URL for a given 
+target_name from `alltime_player_list`
+
+Parameters
+----------
+target_name : string
+    from `alltime_player_list`
+
+Returns
+-------
+url : string
+"""
+def get_player_url(target_name):
+    ln_initial = target_name.split()[-1][0].lower()
+    url = "{}/players/{}/".format(base_url, ln_initial)
+
+    resp = requests.get(url)
+    page_content = BeautifulSoup(resp.content, "html.parser")
+    th = page_content.findAll("th")
+    for row in th:
+        a = row.find("a")
+        if a and a.string == target_name:
+            url = base_url + a["href"]
+    
+    return url
+
+"""
 Function to get the advanced statistic
 for NBA player career
 
@@ -229,16 +256,7 @@ stat_list : list
 """
 def get_adv_stat(name, stat):
     target_name = get_target_name(name)
-    ln_initial = target_name.split()[-1][0].lower()
-    url = "{}/players/{}/".format(base_url, ln_initial)
-
-    resp = requests.get(url)
-    page_content = BeautifulSoup(resp.content, "html.parser")
-    th = page_content.findAll("th")
-    for row in th:
-        a = row.find("a")
-        if a and a.string == target_name:
-            url = base_url + a["href"]
+    url = get_player_url(target_name)
     resp = requests.get(url)
     page_content = BeautifulSoup(resp.content, "html.parser")
     advanced_div = page_content.find("div",attrs={"id":"all_advanced"})

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,5 @@ scikit-learn==0.22.2
 spacy
 beautifulsoup4
 Flask>=0.11
+fuzzywuzzy>=0.18.0
+python-Levenshtein>=0.12.0

--- a/test.py
+++ b/test.py
@@ -66,6 +66,32 @@ class TestScraper(unittest.TestCase):
         for l in bracket:
             self.assertTrue(l in levels)
     
+    # Method to test get target name  
+    def test_get_target_name(self):
+        lebron_jamess = ["LeBron James", "Lebron James", "Lebron"]
+        for i in lebron_jamess:
+            self.assertEqual(scraper.get_target_name(i), "LeBron James")
+        
+        shaquille_oneals = ["Shaquille O'Neal", "Shaq O'Niel", "Shakiel O'Neal"]
+        for i in shaquille_oneals:
+            self.assertEqual(scraper.get_target_name(i), "Shaquille O'Neal")
+        
+        klay_thompsons = ["Klay Thompson", "Clay Thompson", "Clay Thomson", "Klay Thomson"]
+        for i in klay_thompsons:
+            self.assertEqual(scraper.get_target_name(i), "Klay Thompson")
+        
+        kobe_bryants = ["Kobe Bryant", "kobe", "Kobe"]        
+        for i in kobe_bryants:
+            self.assertEqual(scraper.get_target_name(i), "Kobe Bryant")
+        
+        wilt_chamberlains = ["Wilt Chamberlain", "Wilt", "wilt"]        
+        for i in wilt_chamberlains:
+            self.assertEqual(scraper.get_target_name(i), "Wilt Chamberlain")
+
+        dennis_rodmans = ["Dennis Rodman", "Rodman", "rodman"]        
+        for i in dennis_rodmans:
+            self.assertEqual(scraper.get_target_name(i), "Dennis Rodman")
+    
     # Method to test advanced stat scraper 
     def test_get_adv_stats(self):
         names = ["Kobe Bryant", "Lebron James", "Klay Thompson"]

--- a/test.py
+++ b/test.py
@@ -91,7 +91,13 @@ class TestScraper(unittest.TestCase):
         dennis_rodmans = ["Dennis Rodman", "Rodman", "rodman"]        
         for i in dennis_rodmans:
             self.assertEqual(scraper.get_target_name(i), "Dennis Rodman")
-    
+
+    # Method to test get player url  
+    def test_get_player_url(self):
+        self.assertEqual(scraper.get_player_url("Kobe Bryant"), "https://www.basketball-reference.com/players/b/bryanko01.html")
+        self.assertEqual(scraper.get_player_url("LeBron James"), "https://www.basketball-reference.com/players/j/jamesle01.html")
+        self.assertEqual(scraper.get_player_url("Dennis Rodman"), "https://www.basketball-reference.com/players/r/rodmade01.html")
+
     # Method to test advanced stat scraper 
     def test_get_adv_stats(self):
         names = ["Kobe Bryant", "Lebron James", "Klay Thompson"]


### PR DESCRIPTION
This patch addresses issue #20 

I refactor the `get_adv_stat` function. I've pulled out two new functions (`get_target_name` and `get_player_url`) so they can be independently tested.

**get_target_name**
- This function uses the fuzzywuzzy package for string matching.
- I use the `fuzz.partial_token_sort_ratio` metric for string matching. This balances the concurrent problems of partial-string-matches (e.g. Kobe vs Kobe Bryant) and of word order. This metric is case-insensitive. For a good explanation of the different scoring metrics, see: https://chairnerd.seatgeek.com/fuzzywuzzy-fuzzy-string-matching-in-python/
- Tests include a number of example query strings (incl misspellings, partial names, and incorrect capitalisation)

**get_player_url**
- This function has been pulled out of `get_adv_stat` without alteration. This is just for testing purposes.
- FYI - tests use live (non-mocked) requests