### PR TITLE
Replace spaCy sim. method with FuzzyWuzzy matching

### DIFF
--- a/inference/statnode.py
+++ b/inference/statnode.py
@@ -69,6 +69,7 @@ class StatNode(object):
          doc = self.nlp(self.query)
          stat = ""
          stat_final = ""
+         sim_threshold = 50
 
          #preprocessing user query and choosing the most ocurring word classes in statistics dictionary
          for token in doc:
@@ -93,12 +94,13 @@ class StatNode(object):
          # 'doc' gives better results than 'stat', worth continuing to look into
          stat_total, ratio_total = process.extractOne(str(doc), stat_map1)
          stat_adv, ratio_adv = process.extractOne(str(doc), stat_map2)
-         if ratio_total > ratio_adv:
-             stat_final = stat_total
-             return stat_final
+         #if neither ratio is higher than the similarity threshold, return None
+         if ratio_total < sim_threshold and ratio_adv < sim_threshold:
+             return None
+         elif ratio_total > ratio_adv:
+             return stat_total
          else:
-             stat_final = stat_adv
-             return stat_final
+             return stat_adv
 
     def get_player_stat(self, name, stat):
         if stat in total_stat_map:

--- a/inference/statnode.py
+++ b/inference/statnode.py
@@ -2,6 +2,7 @@ import spacy
 import random
 from modules.scraper import get_adv_stat, get_total_stat
 from data.text_data import adv_stat_map, total_stat_map
+from fuzzywuzzy import fuzz, process
 
 inc_name = "Seems I couldn't extract the name for retrieval, try writing your question more verbosely. "
 inc_name += "Unfortunately English is not my native language..."
@@ -63,16 +64,15 @@ class StatNode(object):
                     name = entity.text
 
         return name
-    
+
     def extract_stat(self):
          doc = self.nlp(self.query)
          stat = ""
          stat_final = ""
-         max_sim = 0
-         sim_threshold = 0.7
 
          #preprocessing user query and choosing the most ocurring word classes in statistics dictionary
          for token in doc:
+
              if token.pos_ == "ADJ" or token.pos_ == "VERB" or token.pos_ == "NOUN" or token.pos_ == "NUM" or token.text == "per" or token.pos_ == "SYM" or token.pos_ == "CCONJ":
                  stat = str(stat) + token.text + " "
          stat = stat[:-1]
@@ -83,28 +83,23 @@ class StatNode(object):
                  stat_final = stat
          if stat_final != "":
              return stat_final
-     
-         #if no exact match was found, we need to check similarity between stats and user query
-         stat = self.nlp(stat)
-         for entry in total_stat_map:
-             entry = self.nlp(entry)
-             sim = stat.similarity(entry)
-             if max_sim < sim:
-                 max_sim = sim
-                 stat_final = entry #using stat_final because original variable stat is used to check similarity, so we can not change it
 
-         for entry in adv_stat_map:
-             entry = self.nlp(entry)
-             sim = stat.similarity(entry)
-             if max_sim < sim:
-                 max_sim = sim
-                 stat_final = entry
-         
-         #returning extracted stat if similarity exceeds minimum threshold
-         if(max_sim > sim_threshold):
-             return str(stat_final)
-         return None
-    
+         #if no exact match was found, use fuzzy string matching to find a close match
+         #create lists out of stat maps' keys
+         stat_map1 = total_stat_map.keys()
+         stat_map2 = adv_stat_map.keys()
+
+         #extract fuzzy matches from total and adv stat maps, compare which is closer and return
+         # 'doc' gives better results than 'stat', worth continuing to look into
+         stat_total, ratio_total = process.extractOne(str(doc), stat_map1)
+         stat_adv, ratio_adv = process.extractOne(str(doc), stat_map2)
+         if ratio_total > ratio_adv:
+             stat_final = stat_total
+             return stat_final
+         else:
+             stat_final = stat_adv
+             return stat_final
+
     def get_player_stat(self, name, stat):
         if stat in total_stat_map:
             val = get_total_stat(name, stat)


### PR DESCRIPTION
- in StatNode, switched from using spaCy similarity if no exact match
- to using FuzzyWuzzy fuzzy string matching
- Not perfect, but 3-point stats do not come up for rebounds queries