### PR TITLE
Fixes #117 Joblib Import Failure

### DIFF
--- a/inference/inference_network.py
+++ b/inference/inference_network.py
@@ -1,5 +1,5 @@
 import pickle
-from sklearn.externals import joblib
+import joblib
 from modules.transformer import predictors, query_tokenizer
 from modules.analysis import isNBA
 from inference.ranknode import RankNode

--- a/query_classifier.py
+++ b/query_classifier.py
@@ -6,7 +6,7 @@ warnings.filterwarnings(action='ignore', category=FutureWarning)
 # ML packages
 from sklearn.svm import LinearSVC
 from sklearn.pipeline import Pipeline
-from sklearn.externals import joblib
+import joblib
 from sklearn.metrics import accuracy_score  
 from sklearn.model_selection import train_test_split
 from sklearn.feature_extraction.text import TfidfVectorizer


### PR DESCRIPTION
Please take a look at `query_classifier.py` as it contains other import from `sklearn`.
They might give the same problem in the future.
For now, since they are not flagged out, I choose to leave it as it is.

Fixes #117 